### PR TITLE
[mono-api-html] Add support for writing to both html and markdown at the same time.

### DIFF
--- a/mono-api-html/ApiChange.cs
+++ b/mono-api-html/ApiChange.cs
@@ -9,7 +9,7 @@ namespace Mono.ApiTools {
 	class ApiChange
 	{
 		public string Header;
-		public StringBuilder Member = new StringBuilder ();
+		public TextChunk Member = new TextChunk ();
 		public bool Breaking;
 		public bool AnyChange;
 		public bool HasIgnoredChanges;

--- a/mono-api-html/AssemblyComparer.cs
+++ b/mono-api-html/AssemblyComparer.cs
@@ -83,6 +83,7 @@ namespace Mono.ApiTools {
 			var tb = target.GetAttribute ("version");
 			if (sb != tb) {
 				Output.WriteLine ("<h4>Assembly Version Changed: {0} -> {1}</h4>", sb, tb);
+				Output.WriteLine ();
 			}
 
 			// ? custom attributes ?

--- a/mono-api-html/Comparer.cs
+++ b/mono-api-html/Comparer.cs
@@ -46,19 +46,18 @@ namespace Mono.ApiTools {
 
 		public State State { get; }
 
-		public TextWriter Output {
-			get { return State.Output; }
+		public Formatter Output {
+			get { return Formatter; }
 		}
 
 		public Formatter Formatter {
 			get { return State.Formatter; }
 		}
 
-		protected TextWriter Indent ()
+		protected Formatter Indent ()
 		{
-			for (int i = 0; i < State.Indent; i++)
-				State.Output.Write ("\t");
-			return State.Output;
+			Output.WriteIndentation ();
+			return Output;
 		}
 
 		public abstract void Added (XElement target, bool wasParentAdded);

--- a/mono-api-html/Formatter.cs
+++ b/mono-api-html/Formatter.cs
@@ -33,61 +33,182 @@ using System.Text;
 namespace Mono.ApiTools {
 
 	abstract class Formatter {
+		public string OutputPath { get; set; }
 
-		public Formatter(State state)
+		Stack<(StringBuilder, TextWriter)> builders;
+		public StringBuilder StringBuilder { get; private set; }
+		protected TextWriter output;
+
+		protected int IndentLevel { get; set; }
+
+		protected Formatter (State state, bool isMultiplexed = false)
 		{
 			State = state;
+			if (!isMultiplexed) {
+				StringBuilder = new StringBuilder ();
+				output = new StringWriter (StringBuilder);
+				builders = new Stack<(StringBuilder, TextWriter)> ();
+			}
+		}
+
+		public virtual void Flush ()
+		{
+			output.Flush ();
+		}
+
+		public virtual void WriteLine ()
+		{
+			output.WriteLine ();
+		}
+
+		public virtual void WriteLine (string line)
+		{
+			output.WriteLine (line);
+		}
+
+		public virtual void WriteLine (string format, params object[] arguments)
+		{
+			output.WriteLine (format, arguments);
+		}
+
+		public virtual void WriteLine (StringBuilder sb)
+		{
+			output.WriteLine (sb);
+		}
+
+		public virtual void Write (char value)
+		{
+			output.Write (value);
+		}
+
+		public virtual void Write (string line)
+		{
+			output.Write (line);
+		}
+
+		public virtual void Write (string format, params object [] arguments)
+		{
+			output.Write (format, arguments);
+		}
+
+		public virtual void Write (StringBuilder sb)
+		{
+			output.Write (sb);
+		}
+
+		public virtual void WriteIndentation ()
+		{
+			for (int i = 0; i < IndentLevel; i++)
+				Write ('\t');
 		}
 
 		public State State { get; }
 
+		public virtual void PushOutput ()
+		{
+			builders.Push ((StringBuilder, output));
+			StringBuilder = new StringBuilder ();
+			output = new StringWriter (StringBuilder);
+		}
+
+		public StringBuilder PopOutput ()
+		{
+			var rv = StringBuilder;
+			output.Flush ();
+			output.Dispose ();
+
+			var popped = builders.Pop ();
+			StringBuilder = popped.Item1;
+			output = popped.Item2;
+
+			return rv;
+		}
+
 		public abstract string LesserThan { get; }
 		public abstract string GreaterThan { get; }
 
-		public abstract void BeginDocument (TextWriter output, string title);
-		public virtual void EndDocument (TextWriter output)
+		public abstract void BeginDocument (string title);
+		public virtual void EndDocument ()
 		{
 		}
 
-		public abstract void BeginAssembly (TextWriter output);
-		public virtual void EndAssembly (TextWriter output)
+		public abstract void BeginAssembly ();
+		public virtual void EndAssembly ()
 		{
 		}
 
-		public abstract void BeginNamespace (TextWriter output, string action = "");
-		public virtual void EndNamespace (TextWriter output)
+		public abstract void BeginNamespace (string action = "");
+		public virtual void EndNamespace ()
 		{
 		}
 
-		public abstract void BeginTypeAddition (TextWriter output);
-		public abstract void EndTypeAddition (TextWriter output);
+		public abstract void BeginTypeAddition ();
+		public abstract void EndTypeAddition ();
 
-		public abstract void BeginTypeModification (TextWriter output);
-		public virtual void EndTypeModification (TextWriter output)
+		public abstract void BeginTypeModification ();
+		public virtual void EndTypeModification ()
 		{
 		}
 
-		public abstract void BeginTypeRemoval (TextWriter output);
-		public virtual void EndTypeRemoval (TextWriter output)
+		public abstract void BeginTypeRemoval ();
+		public virtual void EndTypeRemoval ()
 		{
 		}
 
-		public abstract void BeginMemberAddition (TextWriter output, IEnumerable<XElement> list, MemberComparer member);
-		public abstract void AddMember (TextWriter output, MemberComparer member, bool isInterfaceBreakingChange, string obsolete, string description);
-		public abstract void EndMemberAddition (TextWriter output);
+		public abstract void BeginMemberAddition (IEnumerable<XElement> list, MemberComparer member);
+		public abstract void AddMember (MemberComparer member, bool isInterfaceBreakingChange, string obsolete, string description);
+		public abstract void EndMemberAddition ();
 
-		public abstract void BeginMemberModification (TextWriter output, string sectionName);
-		public abstract void EndMemberModification (TextWriter output);
+		public abstract void BeginMemberModification (string sectionName);
+		public abstract void EndMemberModification ();
 
-		public abstract void BeginMemberRemoval (TextWriter output, IEnumerable<XElement> list, MemberComparer member);
-		public abstract void RemoveMember (TextWriter output, MemberComparer member, bool breaking, string obsolete, string description);
-		public abstract void EndMemberRemoval (TextWriter output);
+		public abstract void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member);
+		public abstract void RemoveMember (MemberComparer member, bool breaking, string obsolete, string description);
+		public abstract void EndMemberRemoval ();
 
-		public abstract void RenderObsoleteMessage (StringBuilder output, MemberComparer member, string description, string optionalObsoleteMessage);
+		public abstract void RenderObsoleteMessage (TextChunk chunk, MemberComparer member, string description, string optionalObsoleteMessage);
 
-		public abstract void DiffAddition (StringBuilder output, string text, bool breaking);
-		public abstract void DiffModification (StringBuilder output, string old, string @new, bool breaking);
-		public abstract void DiffRemoval (StringBuilder output, string text, bool breaking);
-		public abstract void Diff (TextWriter output, ApiChange apichange);
+		public abstract void DiffAddition (TextChunk chunk, string text, bool breaking);
+		public abstract void DiffModification (TextChunk chunk, string old, string @new, bool breaking);
+		public abstract void DiffRemoval (TextChunk chunk, string text, bool breaking);
+		public abstract void Diff (ApiChange apichange);
+
+		public virtual void IncreaseIndentation ()
+		{
+			IndentLevel++;
+		}
+
+		public virtual void DecreaseIndentation ()
+		{
+			IndentLevel--;
+		}
+	}
+
+	class TextChunk {
+		List<(Formatter Formatter, StringBuilder StringBuilder)> stringbuilders = new List<(Formatter, StringBuilder)> ();
+
+		StringBuilder cachedOutput = new StringBuilder ();
+		public StringBuilder GetStringBuilder (Formatter formatter)
+		{
+			foreach (var kvp in stringbuilders)
+				if (kvp.Formatter == formatter)
+					return kvp.StringBuilder;
+			var rv = new StringBuilder ();
+			rv.Append (cachedOutput);
+			stringbuilders.Add (new (formatter, rv));
+			return rv;
+		}
+
+		public void Append (string value)
+		{
+			foreach (var kvp in stringbuilders)
+				kvp.StringBuilder.Append (value);
+			cachedOutput.Append (value);
+		}
+
+		public override string ToString ()
+		{
+			throw new InvalidOperationException ();
+		}
 	}
 }

--- a/mono-api-html/HtmlFormatter.cs
+++ b/mono-api-html/HtmlFormatter.cs
@@ -44,13 +44,7 @@ namespace Mono.ApiTools {
 		public override string LesserThan => "&lt;";
 		public override string GreaterThan => "&gt;";
 
-		protected void Indent (TextWriter output)
-		{
-			 for (int i = 0; i < State.Indent; i++)
-			 	output.Write ("\t");
-		}
-
-		public override void BeginDocument (TextWriter output, string title)
+		public override void BeginDocument (string title)
 		{
 			output.WriteLine ("<div>");
 			if (State.Colorize) {
@@ -134,7 +128,7 @@ namespace Mono.ApiTools {
 </script>");
 		}
 
-		public override void BeginAssembly (TextWriter output)
+		public override void BeginAssembly ()
 		{
 			output.WriteLine ($"<h1>{State.Assembly}.dll</h1>");
 			if (!State.IgnoreNonbreaking) {
@@ -145,53 +139,53 @@ namespace Mono.ApiTools {
 			output.WriteLine ("<div data-is-topmost>");
 		}
 
-		public override void EndAssembly (TextWriter output)
+		public override void EndAssembly ()
 		{
 			output.WriteLine ("</div> <!-- end topmost div -->");
 			output.WriteLine ("</div>");
 		}
 
-		public override void BeginNamespace (TextWriter output, string action)
+		public override void BeginNamespace (string action)
 		{
 			output.WriteLine ($"<!-- start namespace {State.Namespace} --> <div>");
 			output.WriteLine ($"<h2>{action}Namespace {State.Namespace}</h2>");
 		}
 
-		public override void EndNamespace (TextWriter output)
+		public override void EndNamespace ()
 		{
 			output.WriteLine ($"</div> <!-- end namespace {State.Namespace} -->");
 		}
 
-		public override void BeginTypeAddition (TextWriter output)
+		public override void BeginTypeAddition ()
 		{
 			output.WriteLine ($"<div> <!-- start type {State.Type} -->");
 			output.WriteLine ($"<h3>New Type {State.Namespace}.{State.Type}</h3>");
 			output.WriteLine ("<pre class='added' data-is-non-breaking>");
 		}
 
-		public override void EndTypeAddition (TextWriter output)
+		public override void EndTypeAddition ()
 		{
 			output.WriteLine ("</pre>");
 			output.WriteLine ($"</div> <!-- end type {State.Type} -->");
 		}
 
-		public override void BeginTypeModification (TextWriter output)
+		public override void BeginTypeModification ()
 		{
 			output.WriteLine ($"<!-- start type {State.Type} --> <div>");
 			output.WriteLine ($"<h3>Type Changed: {State.Namespace}.{State.Type}</h3>");
 		}
 
-		public override void EndTypeModification (TextWriter output)
+		public override void EndTypeModification ()
 		{
 			output.WriteLine ($"</div> <!-- end type {State.Type} -->");
 		}
 
-		public override void BeginTypeRemoval (TextWriter output)
+		public override void BeginTypeRemoval ()
 		{
 			output.Write ($"<h3>Removed Type <span class='breaking' data-is-breaking>{State.Namespace}.{State.Type}</span></h3>");
 		}
 
-		public override void BeginMemberAddition (TextWriter output, IEnumerable<XElement> list, MemberComparer member)
+		public override void BeginMemberAddition (IEnumerable<XElement> list, MemberComparer member)
 		{
 			output.WriteLine ("<div>");
 			if (State.BaseType == "System.Enum") {
@@ -201,35 +195,35 @@ namespace Mono.ApiTools {
 				output.WriteLine ("<p>Added {0}:</p>", list.Count () > 1 ? member.GroupName : member.ElementName);
 				output.WriteLine ("<pre>");
 			}
-			State.Indent++;
+			IndentLevel++;
 		}
 
-		public override void AddMember (TextWriter output, MemberComparer member, bool isInterfaceBreakingChange, string obsolete, string description)
+		public override void AddMember (MemberComparer member, bool isInterfaceBreakingChange, string obsolete, string description)
 		{
 			output.Write ("<span class='added added-{0} {1}' {2}>", member.ElementName, isInterfaceBreakingChange ? "breaking" : string.Empty, isInterfaceBreakingChange ? "data-is-breaking" : "data-is-non-breaking");
 			output.Write ($"{obsolete}{description}");
 			output.WriteLine ("</span>");
 		}
 
-		public override void EndMemberAddition (TextWriter output)
+		public override void EndMemberAddition ()
 		{
-			State.Indent--;
+			IndentLevel--;
 			output.WriteLine ("</pre>");
 			output.WriteLine ("</div>");
 		}
 
-		public override void BeginMemberModification (TextWriter output, string sectionName)
+		public override void BeginMemberModification (string sectionName)
 		{
 			output.WriteLine ($"<p>{sectionName}:</p>");
 			output.WriteLine ("<pre>");
 		}
 
-		public override void EndMemberModification (TextWriter output)
+		public override void EndMemberModification ()
 		{
 			output.WriteLine ("</pre>");
 		}
 
-		public override void BeginMemberRemoval (TextWriter output, IEnumerable<XElement> list, MemberComparer member)
+		public override void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member)
 		{
 			if (State.BaseType == "System.Enum") {
 				output.WriteLine ("<p>Removed value{0}:</p>", list.Count () > 1 ? "s" : String.Empty);
@@ -238,23 +232,24 @@ namespace Mono.ApiTools {
 				output.WriteLine ("<p>Removed {0}:</p>", list.Count () > 1 ? member.GroupName : member.ElementName);
 				output.WriteLine ("<pre>");
 			}
-			State.Indent++;
+			IndentLevel++;
 		}
 
-		public override void RemoveMember (TextWriter output, MemberComparer member, bool breaking, string obsolete, string description)
+		public override void RemoveMember (MemberComparer member, bool breaking, string obsolete, string description)
 		{
-			Indent (output);
+			WriteIndentation ();
 			output.Write ("<span class='removed removed-{0} {2}' {1}>", member.ElementName, breaking ? "data-is-breaking" : "data-is-non-breaking", breaking ? "breaking" : string.Empty);
 			if (obsolete.Length > 0) {
 				output.Write (obsolete);
-				Indent (output);
+				WriteIndentation ();
 			}
 			output.Write (description);
 			output.WriteLine ("</span>");
 		}
 
-		public override void RenderObsoleteMessage (StringBuilder output, MemberComparer member, string description, string optionalObsoleteMessage)
+		public override void RenderObsoleteMessage (TextChunk chunk, MemberComparer member, string description, string optionalObsoleteMessage)
 		{
+			var output = chunk.GetStringBuilder (this);
 			output.Append ($"<span class='obsolete obsolete-{member.ElementName}' data-is-non-breaking>");
 			output.Append ("[Obsolete (");
 			if (!String.IsNullOrEmpty (optionalObsoleteMessage))
@@ -264,14 +259,15 @@ namespace Mono.ApiTools {
 			output.Append ("</span>");
 		}
 
-		public override void EndMemberRemoval (TextWriter output)
+		public override void EndMemberRemoval ()
 		{
-			State.Indent--;
+			IndentLevel--;
 			output.WriteLine ("</pre>");;
 		}
 
-		public override void DiffAddition (StringBuilder output, string text, bool breaking)
+		public override void DiffAddition (TextChunk chunk, string text, bool breaking)
 		{
+			var output = chunk.GetStringBuilder (this);
 			output.Append ("<span class='added ");
 			if (breaking)
 				output.Append ("added-breaking-inline");
@@ -280,18 +276,20 @@ namespace Mono.ApiTools {
 			output.Append ("</span>");
 		}
 
-		public override void DiffModification (StringBuilder output, string old, string @new, bool breaking)
+		public override void DiffModification (TextChunk chunk, string old, string @new, bool breaking)
 		{
+			var output = chunk.GetStringBuilder (this);
 			if (old.Length > 0)
-				DiffRemoval (output, old, breaking);
+				DiffRemoval (chunk, old, breaking);
 			if (old.Length > 0 && @new.Length > 0)
 				output.Append (' ');
 			if (@new.Length > 0)
-				DiffAddition (output, @new, false);
+				DiffAddition (chunk, @new, false);
 		}
 
-		public override void DiffRemoval (StringBuilder output, string text, bool breaking)
+		public override void DiffRemoval (TextChunk chunk, string text, bool breaking)
 		{
+			var output = chunk.GetStringBuilder (this);
 			output.Append ("<span class='removed removed-inline ");
 			if (breaking)
 				output.Append ("removed-breaking-inline");
@@ -300,10 +298,10 @@ namespace Mono.ApiTools {
 			output.Append ("</span>");
 		}
 
-		public override void Diff (TextWriter output, ApiChange apichange)
+		public override void Diff (ApiChange apichange)
 		{
 			output.Write ("<div {0}>", apichange.Breaking ? "data-is-breaking" : "data-is-non-breaking");
-			foreach (var line in apichange.Member.ToString ().Split (new[] { Environment.NewLine }, 0)) {
+			foreach (var line in apichange.Member.GetStringBuilder (this).ToString ().Split (new[] { Environment.NewLine }, 0)) {
 				output.Write ('\t');
 				output.WriteLine (line);
 			}

--- a/mono-api-html/MemberComparer.cs
+++ b/mono-api-html/MemberComparer.cs
@@ -133,13 +133,13 @@ namespace Mono.ApiTools {
 				if (State.IgnoreAdded.Any (re => re.IsMatch (memberDescription)))
 					continue;
 				if (!a) {
-					Formatter.BeginMemberAddition (Output, elements, this);
+					Formatter.BeginMemberAddition (elements, this);
 					a = true;
 				}
 				Added (item, false);
 			}
 			if (a)
-				Formatter.EndMemberAddition (Output);
+				Formatter.EndMemberAddition ();
 		}
 
 		void Modify (ApiChanges modified)
@@ -147,13 +147,13 @@ namespace Mono.ApiTools {
 			foreach (var changes in modified) {
 				if (State.IgnoreNonbreaking && changes.Value.All (c => !c.Breaking))
 					continue;
-				Formatter.BeginMemberModification (Output, changes.Key);
+				Formatter.BeginMemberModification (changes.Key);
 				foreach (var element in changes.Value) {
 					if (State.IgnoreNonbreaking && !element.Breaking)
 						continue;
-					Formatter.Diff (Output, element);
+					Formatter.Diff (element);
 				}
-				Formatter.EndMemberModification (Output);
+				Formatter.EndMemberModification ();
 			}
 		}
 
@@ -169,14 +169,14 @@ namespace Mono.ApiTools {
 				if (State.IgnoreNonbreaking && !IsBreakingRemoval (item))
 					continue;
 				if (!r) {
-					Formatter.BeginMemberRemoval (Output, elements, this);
+					Formatter.BeginMemberRemoval (elements, this);
 					first = true;
 					r = true;
 				}
 				Removed (item);
 			}
 			if (r)
-				Formatter.EndMemberRemoval (Output);
+				Formatter.EndMemberRemoval ();
 		}
 			
 		public abstract string GetDescription (XElement e);
@@ -216,7 +216,7 @@ namespace Mono.ApiTools {
 				Output.WriteLine ();
 			Indent ();
 			bool isInterfaceBreakingChange = !wasParentAdded && IsInInterface (target);
-			Formatter.AddMember (Output, this, isInterfaceBreakingChange, o.ToString (), GetDescription (target));
+			Formatter.AddMember (this, isInterfaceBreakingChange, o.ToString (), GetDescription (target));
 			first = false;
 		}
 
@@ -232,7 +232,7 @@ namespace Mono.ApiTools {
 
 			bool is_breaking = IsBreakingRemoval (source);
 
-			Formatter.RemoveMember (Output, this, is_breaking, o.ToString (), GetDescription (source));
+			Formatter.RemoveMember (this, is_breaking, o.ToString (), GetDescription (source));
 			first = false;
 		}
 

--- a/mono-api-html/MultiplexedFormatter.cs
+++ b/mono-api-html/MultiplexedFormatter.cs
@@ -1,0 +1,252 @@
+﻿// 
+// Authors
+//    Rolf Kvinge <rolf@xamarin.com>
+//
+// Copyright 2022 Microsoft Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using System.Text;
+
+#nullable enable
+
+namespace Mono.ApiTools {
+
+	class MultiplexedFormatter : Formatter {
+		Formatter [] formatters;
+
+		public MultiplexedFormatter (State state, params Formatter [] formatters)
+			: base (state, isMultiplexed: true)
+		{
+			this.formatters = formatters;
+		}
+
+		public override string LesserThan => "%LESSERTHANREPLACEMENT%";
+		public override string GreaterThan => "%GREATERTHANREPLACEMENT%";
+
+		string Replace (Formatter formatter, string text)
+		{
+			return text.Replace (LesserThan, formatter.LesserThan).Replace (GreaterThan, formatter.GreaterThan);
+		}
+
+		public override void BeginDocument (string title)
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginDocument (Replace (formatter, title));
+		}
+
+		public override void BeginAssembly ()
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginAssembly ();
+		}
+
+		public override void BeginNamespace (string action)
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginNamespace (Replace (formatter, action));
+		}
+
+		public override void BeginTypeAddition ()
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginTypeAddition ();
+		}
+
+		public override void EndTypeAddition ()
+		{
+			foreach (var formatter in formatters)
+				formatter.EndTypeAddition ();
+		}
+
+		public override void BeginTypeModification ()
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginTypeModification ();
+		}
+
+		public override void BeginTypeRemoval ()
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginTypeRemoval ();
+		}
+
+		public override void BeginMemberAddition (IEnumerable<XElement> list, MemberComparer member)
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginMemberAddition (list, member);
+		}
+
+		public override void AddMember (MemberComparer member, bool isInterfaceBreakingChange, string obsolete, string description)
+		{
+			foreach (var formatter in formatters)
+				formatter.AddMember (member, isInterfaceBreakingChange, Replace (formatter, obsolete), Replace (formatter, description));
+		}
+
+		public override void EndMemberAddition ()
+		{
+			foreach (var formatter in formatters)
+				formatter.EndMemberAddition ();
+		}
+
+		public override void BeginMemberModification (string sectionName)
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginMemberModification (Replace (formatter, sectionName));
+		}
+
+		public override void EndMemberModification ()
+		{
+			foreach (var formatter in formatters)
+				formatter.EndMemberModification ();
+		}
+
+		public override void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member)
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginMemberRemoval (list, member);
+		}
+
+		public override void RemoveMember (MemberComparer member, bool is_breaking, string obsolete, string description)
+		{
+			foreach (var formatter in formatters)
+				formatter.RemoveMember (member, is_breaking, Replace (formatter, obsolete), Replace (formatter, description));
+		}
+
+		public override void EndMemberRemoval ()
+		{
+			foreach (var formatter in formatters)
+				formatter.EndMemberRemoval ();
+		}
+
+		public override void RenderObsoleteMessage (TextChunk chunk, MemberComparer member, string description, string optionalObsoleteMessage)
+		{
+			foreach (var formatter in formatters)
+				formatter.RenderObsoleteMessage (chunk, member, Replace (formatter, description), Replace (formatter, optionalObsoleteMessage));
+		}
+
+		public override void DiffAddition (TextChunk chunk, string text, bool breaking)
+		{
+			foreach (var formatter in formatters)
+				formatter.DiffAddition (chunk, Replace (formatter, text), breaking);
+		}
+
+		public override void DiffModification (TextChunk chunk, string old, string @new, bool breaking)
+		{
+			foreach (var formatter in formatters)
+				formatter.DiffModification (chunk, Replace (formatter, old), Replace (formatter, @new), breaking);
+		}
+
+		public override void DiffRemoval (TextChunk chunk, string text, bool breaking)
+		{
+			foreach (var formatter in formatters)
+				formatter.DiffRemoval (chunk, Replace (formatter, text), breaking);
+		}
+
+		public override void Diff (ApiChange apichange)
+		{
+			foreach (var formatter in formatters)
+				formatter.Diff (apichange);
+		}
+
+		public override void PushOutput ()
+		{
+			foreach (var formatter in formatters)
+				formatter.PushOutput ();
+		}
+
+		public override void IncreaseIndentation ()
+		{
+			foreach (var formatter in formatters)
+				formatter.IncreaseIndentation ();
+		}
+
+		public override void DecreaseIndentation ()
+		{
+			foreach (var formatter in formatters)
+				formatter.DecreaseIndentation ();
+		}
+
+		public override void WriteIndentation ()
+		{
+			foreach (var formatter in formatters)
+				formatter.WriteIndentation ();
+		}
+
+		public override void Flush ()
+		{
+			foreach (var formatter in formatters)
+				formatter.Flush ();
+		}
+
+		public override void WriteLine ()
+		{
+			foreach (var formatter in formatters)
+				formatter.WriteLine ();
+		}
+
+		public override void WriteLine (string line)
+		{
+			foreach (var formatter in formatters)
+				formatter.WriteLine (line);
+		}
+
+		public override void WriteLine (string format, params object [] arguments)
+		{
+			foreach (var formatter in formatters)
+				formatter.WriteLine (format, arguments);
+		}
+
+		public override void WriteLine (StringBuilder sb)
+		{
+			foreach (var formatter in formatters)
+				formatter.WriteLine (sb);
+		}
+
+		public override void Write (char value)
+		{
+			foreach (var formatter in formatters)
+				formatter.Write (value);
+		}
+
+		public override void Write (string line)
+		{
+			foreach (var formatter in formatters)
+				formatter.Write (line);
+		}
+
+		public override void Write (string format, params object [] arguments)
+		{
+			foreach (var formatter in formatters)
+				formatter.Write (format, arguments);
+		}
+
+		public override void Write (StringBuilder sb)
+		{
+			foreach (var formatter in formatters)
+				formatter.Write (sb);
+		}
+	}
+}

--- a/mono-api-html/NamespaceComparer.cs
+++ b/mono-api-html/NamespaceComparer.cs
@@ -63,28 +63,28 @@ namespace Mono.ApiTools {
 			if (State.IgnoreNew.Any (re => re.IsMatch (namespaceDescription)))
 				return;
 
-			Formatter.BeginNamespace (Output, "New ");
+			Formatter.BeginNamespace ("New ");
 			// list all new types
 			foreach (var addedType in target.Element ("classes").Elements ("class")) {
 				State.Type = addedType.Attribute ("name").Value;
 				comparer.Added (addedType, true);
 			}
-			Formatter.EndNamespace (Output);
+			Formatter.EndNamespace ();
 		}
 
 		public override void Modified (XElement source, XElement target, ApiChanges differences)
 		{
-			var output = Output;
-			State.Output = new StringWriter ();
+			Formatter.PushOutput ();
+
 			comparer.Compare (source, target);
 
-			var s = Output.ToString ();
-			State.Output = output;
-			if (s.Length > 0) {
-				var name = target.Attribute ("name").Value;
-				Formatter.BeginNamespace (Output);
-				Output.WriteLine (s);
-				Formatter.EndNamespace (Output);
+			foreach (var formatter in State.Formatters) {
+				var s = formatter.PopOutput ();
+				if (s.Length > 0) {
+					formatter.BeginNamespace ();
+					formatter.WriteLine (s);
+					formatter.EndNamespace ();
+				}
 			}
 		}
 
@@ -97,14 +97,14 @@ namespace Mono.ApiTools {
 			if (State.IgnoreRemoved.Any (re => re.IsMatch (namespaceDescription)))
 				return;
 
-			Formatter.BeginNamespace (Output, "Removed ");
+			Formatter.BeginNamespace ("Removed ");
 			Output.WriteLine ();
 			// list all removed types
 			foreach (var removedType in source.Element ("classes").Elements ("class")) {
 				State.Type = comparer.GetTypeName (removedType);
 				comparer.Removed (removedType);
 			}
-			Formatter.EndNamespace (Output);
+			Formatter.EndNamespace ();
 		}
 	}
 }


### PR DESCRIPTION
This way we don't have to execute mono-api-html twice to get output in both formats.