### PR TITLE
[mono-api-html] Output a hardcoded comment if there are any breaking changes.

### DIFF
--- a/mono-api-html/HtmlFormatter.cs
+++ b/mono-api-html/HtmlFormatter.cs
@@ -41,6 +41,8 @@ namespace Mono.ApiTools {
 		{
 		}
 
+		public bool AnyBreakingChanges;
+
 		public override string LesserThan => "&lt;";
 		public override string GreaterThan => "&gt;";
 
@@ -149,6 +151,8 @@ namespace Mono.ApiTools {
 		{
 			output.WriteLine ("</div> <!-- end topmost div -->");
 			output.WriteLine ("</div>");
+			if (AnyBreakingChanges)
+				output.WriteLine ($"<!-- BreakingChangesDetected -->");
 		}
 
 		public override void BeginNamespace (TextWriter output, string action)
@@ -189,6 +193,7 @@ namespace Mono.ApiTools {
 		public override void BeginTypeRemoval (TextWriter output)
 		{
 			output.Write ($"<h3>Removed Type <span class='breaking' data-is-breaking>{State.Namespace}.{State.Type}</span></h3>");
+			AnyBreakingChanges = true;
 		}
 
 		public override void BeginMemberAddition (TextWriter output, IEnumerable<XElement> list, MemberComparer member)
@@ -209,6 +214,8 @@ namespace Mono.ApiTools {
 			output.Write ("<span class='added added-{0} {1}' {2}>", member.ElementName, isInterfaceBreakingChange ? "breaking" : string.Empty, isInterfaceBreakingChange ? "data-is-breaking" : "data-is-non-breaking");
 			output.Write ($"{obsolete}{description}");
 			output.WriteLine ("</span>");
+			if (isInterfaceBreakingChange)
+				AnyBreakingChanges = true;
 		}
 
 		public override void EndMemberAddition (TextWriter output)
@@ -234,6 +241,7 @@ namespace Mono.ApiTools {
 			if (State.BaseType == "System.Enum") {
 				output.WriteLine ("<p>Removed value{0}:</p>", list.Count () > 1 ? "s" : String.Empty);
 				output.WriteLine ("<pre class='removed' data-is-breaking>");
+				AnyBreakingChanges = true;
 			} else {
 				output.WriteLine ("<p>Removed {0}:</p>", list.Count () > 1 ? member.GroupName : member.ElementName);
 				output.WriteLine ("<pre>");
@@ -251,6 +259,8 @@ namespace Mono.ApiTools {
 			}
 			output.Write (description);
 			output.WriteLine ("</span>");
+			if (breaking)
+				AnyBreakingChanges = true;
 		}
 
 		public override void RenderObsoleteMessage (StringBuilder output, MemberComparer member, string description, string optionalObsoleteMessage)
@@ -308,6 +318,8 @@ namespace Mono.ApiTools {
 				output.WriteLine (line);
 			}
 			output.Write ("</div>");
+			if (apichange.Breaking)
+				AnyBreakingChanges = true;
 		}
 	}
 }


### PR DESCRIPTION
Output a hardcoded comment in html so consumers can easily grep for this comment
to verify if there are any breaking changes or not.