### PR TITLE
[mono-api-info] Add support for comparing function pointers.

### DIFF
--- a/mono-api-info/Util.cs
+++ b/mono-api-info/Util.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Cecil;
+using Mono.Collections.Generic;
 
 namespace Mono.ApiTools {
 
@@ -173,11 +174,16 @@ namespace Mono.ApiTools {
 			if (!TypeMatch (candidate.ReturnType, method.ReturnType))
 				return false;
 
-			if (candidate.Parameters.Count != method.Parameters.Count)
+			return ParametersMatch (candidate.Parameters, method.Parameters);
+		}
+
+		bool ParametersMatch (Collection<ParameterDefinition> a, Collection<ParameterDefinition> b)
+		{
+			if (a.Count != b.Count)
 				return false;
 
-			for (int i = 0; i < candidate.Parameters.Count; i++)
-				if (!TypeMatch (candidate.Parameters [i].ParameterType, method.Parameters [i].ParameterType))
+			for (int i = 0; i < a.Count; i++)
+				if (!TypeMatch (a [i].ParameterType, b [i].ParameterType))
 					return false;
 
 			return true;
@@ -199,7 +205,21 @@ namespace Mono.ApiTools {
 			if (a is IModifierType)
 				return TypeMatch ((IModifierType) a, (IModifierType) b);
 
+			if (a is FunctionPointerType fptA && b is FunctionPointerType fptB)
+				return TypeMatch (fptA, fptB);
+
 			return TypeMatch (a.ElementType, b.ElementType);
+		}
+
+		public bool TypeMatch (FunctionPointerType a, FunctionPointerType b)
+		{
+			if (!TypeMatch (a.ReturnType, b.ReturnType))
+				return false;
+
+			if (a.Name != b.Name)
+				return false;
+
+			return ParametersMatch (a.Parameters, b.Parameters);
 		}
 
 		public bool TypeMatch (GenericInstanceType a, GenericInstanceType b)


### PR DESCRIPTION
This fixes a NullReferenceException when processing assemblies in .NET 8:

    System.NullReferenceException: Object reference not set to an instance of an object.
       at Mono.ApiTools.TypeHelper.TypeMatch(TypeReference a, TypeReference b) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/Util.cs:line 235
       at Mono.ApiTools.TypeHelper.TypeMatch(TypeSpecification a, TypeSpecification b) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/Util.cs:line 202
       at Mono.ApiTools.TypeHelper.TypeMatch(TypeReference a, TypeReference b) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/Util.cs:line 232
       at Mono.ApiTools.TypeHelper.MethodMatch(MethodDefinition candidate, MethodDefinition method) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/Util.cs:line 180
       at Mono.ApiTools.TypeHelper.TryMatchMethod(TypeDefinition type, MethodDefinition method) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/Util.cs:line 159
       at Mono.ApiTools.TypeHelper.GetBaseMethodInTypeHierarchy(MethodDefinition method) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/Util.cs:line 143
       at Mono.ApiTools.MethodData.AddExtraAttributes(MemberReference memberDefinition) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/mono-api-info.cs:line 1216
       at Mono.ApiTools.MemberData.DoOutput() in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/mono-api-info.cs:line 523
       at Mono.ApiTools.TypeData.DoOutput() in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/mono-api-info.cs:line 713
       at Mono.ApiTools.AssemblyData.DoOutput() in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/mono-api-info.cs:line 484
       at Mono.ApiTools.AssemblyCollection.DoOutput() in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/mono-api-info.cs:line 334
       at Mono.ApiTools.ApiInfo.Generate(IEnumerable`1 assemblyFiles, IEnumerable`1 assemblyStreams, TextWriter outStream, State state) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/mono-api-info.cs:line 260
       at Mono.ApiTools.ApiInfo.Generate(IEnumerable`1 assemblyPaths, IEnumerable`1 assemblyStreams, TextWriter outStream, ApiInfoConfig config) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/mono-api-info.cs:line 208
       at Mono.ApiTools.Driver.Main(String[] args) in /Users/builder/azdo/_work/1/s/xamarin-macios/external/api-tools/mono-api-info/mono-api-info.cs:line 91
    make: *** [/Users/builder/azdo/_work/1/a/change-detection/tmp/previous-api-comparison/updated-references/dotnet/Microsoft.macOS.Ref/ref/net8.0/Microsoft.macOS.xml] Error 1