### PR TITLE
[mono-api-html] Allow changing the base type if the old base type is a super class of the new base type.

### DIFF
--- a/mono-api-html/ApiDiff.cs
+++ b/mono-api-html/ApiDiff.cs
@@ -37,6 +37,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace Mono.ApiTools {
 
@@ -58,6 +59,9 @@ namespace Mono.ApiTools {
 		public bool Lax { get; set; }
 		public bool Colorize { get; set; } = true;
 		public int Verbosity { get; set; }
+		public string SourceFile;
+		public string TargetFile;
+		public Dictionary<string, string> TargetClassHierarchyMap;
 
 		public void LogDebugMessage (string value)
 		{
@@ -180,13 +184,8 @@ namespace Mono.ApiTools {
 	public static class ApiDiffFormatted {
 		public static void Generate (string firstInfo, string secondInfo, ApiDiffFormattedConfig config = null)
 		{
-			var state = CreateState (config);
-			Generate (firstInfo, secondInfo, state);
-		}
-
-		internal static void Generate (string firstInfo, string secondInfo, State state)
-		{
-			var ac = new AssemblyComparer (firstInfo, secondInfo, state);
+			var state = CreateState (config, firstInfo, secondInfo);
+			var ac = new AssemblyComparer (state);
 			Generate (ac, state);
 		}
 
@@ -214,7 +213,7 @@ namespace Mono.ApiTools {
 			}
 		}
 
-		static State CreateState (ApiDiffFormattedConfig config)
+		static State CreateState (ApiDiffFormattedConfig config, string firstInfo, string secondInfo)
 		{
 			if (config == null)
 				config = new ApiDiffFormattedConfig ();
@@ -227,6 +226,8 @@ namespace Mono.ApiTools {
 				IgnoreNonbreaking = config.IgnoreNonbreaking,
 				IgnoreParameterNameChanges = config.IgnoreParameterNameChanges,
 				Lax = config.IgnoreDuplicateXml,
+				SourceFile = firstInfo,
+				TargetFile = secondInfo,
 
 				Verbosity = config.Verbosity
 			};

--- a/mono-api-html/AssemblyComparer.cs
+++ b/mono-api-html/AssemblyComparer.cs
@@ -37,13 +37,8 @@ namespace Mono.ApiTools {
 		XDocument target;
 		NamespaceComparer comparer;
 
-		public AssemblyComparer (string sourceFile, string targetFile, State state)
-			: this (XDocument.Load(sourceFile), XDocument.Load(targetFile), state)
-		{
-		}
-
-		public AssemblyComparer (Stream sourceFile, Stream targetFile, State state)
-			: this (XDocument.Load(sourceFile), XDocument.Load(targetFile), state)
+		public AssemblyComparer (State state)
+			: this (XDocument.Load(state.SourceFile), XDocument.Load(state.TargetFile), state)
 		{
 		}
 

--- a/mono-api-html/ClassComparer.cs
+++ b/mono-api-html/ClassComparer.cs
@@ -199,18 +199,76 @@ namespace Mono.ApiTools {
 			Indent ().WriteLine ("}");
 		}
 
-		//HACK: we don't have hierarchy information here so just check some basic heuristics for now
 		bool IsBaseChangeCompatible (string source, string target)
 		{
-			if (source == "System.Object")
-				return true;
-			if (source == "System.Exception" && target.EndsWith ("Exception", StringComparison.Ordinal))
-				return true;
-			if (source == "System.EventArgs" && target.EndsWith ("EventArgs", StringComparison.Ordinal))
-				return true;
-			if (source == "System.Runtime.InteropServices.SafeHandle" && target.StartsWith ("Microsoft.Win32.SafeHandles.SafeHandle", StringComparison.Ordinal))
-				return true;
+			if (State.TargetClassHierarchyMap is null)
+				State.TargetClassHierarchyMap = CreateClassHierarchyMap (State.TargetFile);
+
+			// Changing a type hierarchy like this:
+			//
+			// class UIPointerStyle : NSObject {}
+			// class UIHoverStyle : NSObject {}
+			//
+			// to
+			//
+			// class UIPointerStyle : UIHoverStyle {}
+			// class UIHoverStyle : NSObject {}
+			//
+			// is considered a compatible change.
+			// There are a few caveats, but we're hoping they're corner cases we won't hit:
+			//	* A type can be introduced into a hierarchy between two existing types if it doesn't introduce any new abstract members or change the semantics or behavior of existing types.
+			//  * https://learn.microsoft.com/en-us/dotnet/core/compatibility/library-change-rules
+
+			var nextTarget = target;
+			while (State.TargetClassHierarchyMap.TryGetValue (nextTarget, out var nextBase)) {
+				if (nextBase == source)
+					return true;
+				nextTarget = nextBase;
+			}
+
 			return false;
+		}
+
+		// Create a map of a type and its base type.
+		static Dictionary<string, string> CreateClassHierarchyMap (string xml)
+		{
+			var rv = new Dictionary<string, string> ();
+			// We need to load the XDocument again, because the one we're processing might have been modified (things are removed as comparison progresses).
+			// Also it's rare to need this class hierarchy map (base class changes aren't very common), so creating the map when the XDocuments are
+			// originally loaded would incur the cost of computing the map for every api comparison, not only when we need the map.
+			var document = XDocument.Load (xml);
+			foreach (var assemblies in document.Elements ("assemblies")) {
+				foreach (var @assembly in assemblies.Elements ("assembly")) {
+					foreach (var e in assembly.Elements ("namespaces")) {
+						foreach (var nsElement in e.Elements ("namespace")) {
+							var ns = nsElement.GetAttribute ("name");
+							foreach (var classesElement in nsElement.Elements ("classes")) {
+								MapClasses (rv, ns, string.Empty, classesElement);
+							}
+						}
+					}
+				}
+			}
+			return rv;
+
+			static void MapClasses (Dictionary<string, string> dictionary, string @namespace, string declaringType, XElement classes)
+			{
+				foreach (var classElement in classes.Elements ("class")) {
+					var className = classElement.GetAttribute ("name");
+					var baseType = classElement.GetAttribute ("base");
+					string fullname;
+					if (string.IsNullOrEmpty (@namespace)) {
+						// nested type
+						fullname = declaringType + "/" + className;
+					} else {
+						fullname = @namespace + "." + className;
+					}
+					dictionary.Add (fullname, baseType);
+					foreach (var nestedClassesElement in classElement.Elements ("classes")) {
+						MapClasses (dictionary, string.Empty, fullname, nestedClassesElement);
+					}
+				}
+			}
 		}
 
 		public override void Modified (XElement source, XElement target, ApiChanges diff)
@@ -222,13 +280,14 @@ namespace Mono.ApiTools {
 			var tb = target.GetAttribute ("base");
 			var rm = $"{State.Namespace}.{State.Type}: Modified base type: '{sb}' to '{tb}'";
 			State.LogDebugMessage ($"Possible -r value: {rm}");
-			if (sb != tb &&
-					!State.IgnoreRemoved.Any (re => re.IsMatch (rm)) &&
-					!(State.IgnoreNonbreaking && IsBaseChangeCompatible (sb, tb))) {
-				Formatter.BeginMemberModification ("Modified base type");
-				var apichange = new ApiChange ($"{State.Namespace}.{State.Type}", State).AppendModified (sb, tb, true);
-				Formatter.Diff (apichange);
-				Formatter.EndMemberModification ();
+			if (sb != tb &&	!State.IgnoreRemoved.Any (re => re.IsMatch (rm))) {
+				var isCompatible = IsBaseChangeCompatible (sb, tb);
+				if (!(State.IgnoreNonbreaking && isCompatible)) {
+					Formatter.BeginMemberModification ("Modified base type");
+					var apichange = new ApiChange ($"{State.Namespace}.{State.Type}", State).AppendModified (sb, tb, !isCompatible);
+					Formatter.Diff (apichange);
+					Formatter.EndMemberModification ();
+				}
 			}
 
 			ccomparer.Compare (source, target);


### PR DESCRIPTION
Changing a type hierarchy like this:

    class UIPointerStyle : NSObject {}
    class UIHoverStyle : NSObject {}

to

    class UIPointerStyle : UIHoverStyle {}
    class UIHoverStyle : NSObject {}

is (typically) not a breaking change, so allow it.