### PR TITLE
[mono-api-html] Handle default interface members better.

### DIFF
--- a/mono-api-html/MemberComparer.cs
+++ b/mono-api-html/MemberComparer.cs
@@ -215,7 +215,9 @@ namespace Mono.ApiTools {
 			if (!first && (o.Length > 0))
 				Output.WriteLine ();
 			Indent ();
-			bool isInterfaceBreakingChange = !wasParentAdded && IsInInterface (target);
+			var isInterfaceBreakingChange = false;
+			if (!wasParentAdded)
+				isInterfaceBreakingChange = string.Equals ("true", target.Attribute ("abstract")?.Value, StringComparison.Ordinal);
 			Formatter.AddMember (this, isInterfaceBreakingChange, o.ToString (), GetDescription (target));
 			first = false;
 		}


### PR DESCRIPTION
Adding a default interface member to an existing interface isn't a breaking
change, so don't detect it as such.